### PR TITLE
Use Dockerhub images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,14 @@
 gen-docker:
-	# TODO - change tag to dockerhub
 	docker build \
 		-f workivabuild.Dockerfile \
-		-t drydock.workiva.net/workiva/eva:latest-release .
+		-t workivadocker/eva:latest-release .
 
 gen-docker-no-tests:
 	# TODO - change tag to dockerhub
 	docker build \
 		--build-arg SKIP_TESTS=true \
 		-f workivabuild.Dockerfile \
-		-t drydock.workiva.net/workiva/eva:latest-release .
+		-t workivadocker/eva:latest-release .
 
 run-docker:
 	./scripts/ci/pull_composes.sh

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -4,9 +4,9 @@ services:
     ports:
       - 3306:3306
 
-  eva-legacy:
+  eva:
     environment:
-      - EVA_CATALOG_ADDRESS=http://eva-catalog-legacy:3000
+      - EVA_CATALOG_ADDRESS=http://eva-catalog:3000
     ports:
       - 9999:9999
       - 61616:61616

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -11,10 +11,10 @@ services:
       - 9999:9999
       - 61616:61616
 
-  eva-catalog-legacy:
-    ports:
-      - 3000:3000
-    environment:
-      - EVA_CATALOG_DATA=/catalog-config.edn
-    volumes:
-      - ${SKYNET_TESTING_PATH}/server/test-resources/eva/server/v2/catalog_config.edn:/catalog-config.edn
+#  eva-catalog:
+#    ports:
+#      - 3000:3000
+#    environment:
+#      - EVA_CATALOG_DATA=/catalog-config.edn
+#    volumes:
+#      - server/test-resources/eva/server/v2/catalog_config.edn:/catalog-config.edn

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,9 +15,8 @@ services:
     environment:
       - ACTIVEMQ_ACTIVEMQ_USERS_EVA="eva"
 
-  eva-catalog-legacy:
-    # TODO - replace with dockerhub image
-    image: ${SKYNET_APPLICATION_EVA_CATALOG_LEGACY:-drydock.workiva.net/workiva/eva-catalog-legacy:latest-release}
+  eva-catalog:
+    image: workivadocker/eva-catalog:latest-release
     healthcheck:
       test: wget -q -O - http://eva-catalog-legacy:3000/status || exit 1
 
@@ -26,8 +25,8 @@ services:
       - activemq
       - eva-db
       - eva-catalog-legacy
-    # TODO - replace with dockerhub image
-    image: '${SKYNET_APPLICATION_EVA:-drydock.workiva.net/workiva/eva:latest-release}'
+      - eva-catalog
+    image: workivadocker/eva:latest-release
     environment:
       - EVA_BROKER_HOST=activemq
       - EVA_TRANSACTORS_CONFIG=/local_transactors_test_config.clj

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,13 +18,12 @@ services:
   eva-catalog:
     image: workivadocker/eva-catalog:latest-release
     healthcheck:
-      test: wget -q -O - http://eva-catalog-legacy:3000/status || exit 1
+      test: wget -q -O - http://eva-catalog:3000/status || exit 1
 
-  eva-legacy:
+  eva:
     depends_on:
       - activemq
       - eva-db
-      - eva-catalog-legacy
       - eva-catalog
     image: workivadocker/eva:latest-release
     environment:

--- a/scripts/ci/pull_composes.sh
+++ b/scripts/ci/pull_composes.sh
@@ -15,8 +15,8 @@ mkdir eva-catalog && cd eva-catalog
 git init && git remote add origin git@github.com:Workiva/eva-catalog.git
 git fetch --tags
 echo Checking out compose for eva-catalog at $(git describe --tags $(git rev-list --tags --max-count=1))
-git checkout $(git describe --tags $(git rev-list --tags --max-count=1)) -- docker-compose.yml
+git checkout $(git describe --tags $(git rev-list --tags --max-count=1)) -- docker/docker-compose.yml
 cd ../..
-cp compose_remote/eva-catalog/docker-compose.yml ./compose_remote/local-compose-eva-catalog.yml
+cp compose_remote/eva-catalog/docker/docker-compose.yml ./compose_remote/local-compose-eva-catalog.yml
 rm -rf compose_remote/eva-catalog
 echo local-compose-eva-catalog.yaml cloned to compose_remote dir


### PR DESCRIPTION
## Description of Changes

  - Update docker to use dockerhub images.

## Proposed Testing Steps (If Applicable)

  - Run through `Running with Docker` part of readme.

## Relevant Issues (If Applicable)

  - Currently doesn't work, `make repl` fails when trying to require catalog.

## Maintainer Notifications

  - @erikpetersen-wf
