### PR TITLE
Remove transactor groups env var to fix issue with other catalog configs.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - EVA_TRANSACTORS_CONFIG=/local_transactors_test_config.clj
       - LOGBACK_LOG_LEVEL=DEBUG
       - EVA_SERVER_MODE=TRANSACTORS_NODE
-      - EVA_TRANSACTOR_GROUPS=eva-test
       - EVA_DEFAULT_TRANSACTOR=true
       - LOGBACK_APPENDER=STDOUT
       - JAVA_OPTS=-Dlogback.configurationFile=/local_logback.xml


### PR DESCRIPTION
## Description of Changes
- Explicitly setting `EVA_TRANSACTOR_GROUPS` breaks configs which don't contain the value set.  For example, https://github.com/Workiva/eva-catalog/blob/master/workivabuild/local-catalog-config.edn, does not set any explicit transactor groups, which causes the transactor to *not* startup when it is stood up, for example, by the eva-client-service.

## Proposed Testing Steps (If Applicable)
- Commented out the line when running `make run-docker` in the client service and everything worked fine.

## Relevant Issues (If Applicable)
- We shouldn't really maintain multiple config files.  We should seek to deprecate/remove the catalog config contained within eva, and opt to use the config contained in the catalog solely. 

## Maintainer Notifications

  - @erikpetersen-wf
