### PR TITLE
Remove reference to eva team from error message

### DIFF
--- a/core/src/eva/v2/transaction_pipeline/validation.clj
+++ b/core/src/eva/v2/transaction_pipeline/validation.clj
@@ -349,7 +349,7 @@
 ;; alternate strategy: system/exit
 (defn raise-skew-exception [local-now last-tx-inst skew-window]
   (tx-err/raise-clock-skew
-   "This transactor's clock is more than the allotted skew window behind the previous transaction log entry. Please report this exception to the Eva team."
+   "This transactor's clock is more than the allotted skew window behind the previous transaction log entry."
    {:local-now local-now
     :last-tx-inst last-tx-inst
     :skew-window skew-window


### PR DESCRIPTION
This part of the comment no longer makes sense given that this is now oss. Note - a further improvement might be to suggest making an issue in the eva repo in error cases where that would be appropriate.

## Description of Changes

  - Removed the part of the error message for rais-clock-skew which asked to contact the eva team. This part of the error message is no longer applicable with eva being open source.

## Proposed Testing Steps (If Applicable)

  - Throw a raise-clock-skew (somehow?) and ensure that the error message has, in fact, been changed.

## Relevant Issues (If Applicable)

  - https://github.com/Workiva/eva/issues/75

## Maintainer Notifications

  - @erikpetersen-wf
