### PR TITLE
Update the deprecated build arg BUILD_ARTIFACTS_ARTIFACTORY to BUILD_ARTIFACTS_JAVA.

### DIFF
--- a/workivabuild.Dockerfile
+++ b/workivabuild.Dockerfile
@@ -29,7 +29,7 @@ RUN ./scripts/ci/workiva-build.sh
 
 # Artifacts
 ARG BUILD_ARTIFACTS_DOCUMENTATION=/build/eva-api-docs.tgz
-ARG BUILD_ARTIFACTS_ARTIFACTORY=/build/eva-*.jar
+ARG BUILD_ARTIFACTS_JAVA=/build/eva-*.jar
 
 # Prepare Veracode Artifact (Transactor & Client Library)
 FROM clojure:openjdk-8-lein-2.8.3-alpine AS veracode


### PR DESCRIPTION
https://jira.atl.workiva.net/browse/CID-947

The BUILD_ARTIFACTS_ARTIFACTORY build arg has been deprecated and replaced/made synonymous with BUILD_ARTIFACTS_JAVA as
noted in the workiva-build [user guide](https://github.com/Workiva/workiva-build/blob/master/doc/user_guide.md#artifacts)

[CID](https://github.com/Workiva/cid) will no longer support the deprecated BUILD_ARTIFACTS_ARTIFACTORY, so repositories
will need to have it replaced before the eventual transition.

Please reach out to `#support-cid` or `#support-build` with any questions.

[_Created by Sourcegraph batch change `Workiva/remove_deprecated_build_args`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_deprecated_build_args)